### PR TITLE
Brings existing zone under Terraform

### DIFF
--- a/src/terraform/main.tf
+++ b/src/terraform/main.tf
@@ -1,0 +1,14 @@
+locals {
+  dns_name = "crdant.dev."
+}
+
+resource "google_dns_managed_zone" "crdant_dev" {
+  name        = "crdant-dev"
+  dns_name    = local.dns_name
+  description = "Domain for development activities" 
+  
+  dnssec_config {
+    state         = "on"
+  }
+}
+


### PR DESCRIPTION
TL;DR
-----

Starts using Terraform for `crdant.dev`

Details
-------

Adds the existing managed zone to the Terraform templates so that
I could import it and start using this repository to manage it.
