### PR TITLE
Fixes CAA record in Terraform

### DIFF
--- a/src/terraform/main.tf
+++ b/src/terraform/main.tf
@@ -19,7 +19,7 @@ resource "google_dns_record_set" "crdant_dev_caa" {
   ttl          = 300
 
   rrdatas = [
-    "0 issue letsencrypt.org"
+    "0 issue \"letsencrypt.org\""
   ]
 }
 


### PR DESCRIPTION
TL;DR
-----

Updates the data in the CAA record to prevent spurious mismatches

Details
-------

The value of the CAA record was applying correctly but GCP was
making an update to put the `letsencrypt.org` in quotes. This led
to spurious "changes" on plan/apply. Updates the value to only
show real changes.
